### PR TITLE
fixed compile errors in combobox and entrycompletion

### DIFF
--- a/combobox.vala
+++ b/combobox.vala
@@ -8,7 +8,7 @@ using Gtk;
 
 public class Example : Window
 {
-    private ListStore liststore;
+    private Gtk.ListStore liststore;
     private ComboBox combobox;
     private CellRendererText cellrenderertext;
 
@@ -17,7 +17,7 @@ public class Example : Window
         this.title = "ComboBox";
         this.destroy.connect(Gtk.main_quit);
 
-        liststore = new ListStore(1, typeof (string));
+        liststore = new Gtk.ListStore(1, typeof (string));
         Gtk.TreeIter iter;
 
         liststore.append(out iter);

--- a/entrycompletion.vala
+++ b/entrycompletion.vala
@@ -7,7 +7,7 @@ using Gtk;
 
 public class EntryExample : Window
 {
-    private ListStore liststore;
+    private Gtk.ListStore liststore;
     private Entry entry;
     private EntryCompletion entrycompletion;
 
@@ -19,7 +19,7 @@ public class EntryExample : Window
         entry = new Entry();
         this.add(entry);
 
-        liststore = new ListStore(1, typeof(string));
+        liststore = new Gtk.ListStore(1, typeof(string));
 
         Gtk.TreeIter iter;
         liststore.append(out iter);


### PR DESCRIPTION
Was getting this error for both files:
```
entrycompletion.vala:10.13-10.21: error: `ListStore' is an ambiguous reference between `GLib.ListStore' and `Gtk.ListStore'
    private ListStore liststore;
            ^^^^^^^^^
Compilation failed: 1 error(s), 0 warning(s)
```